### PR TITLE
Let browserify vs node switch the dependencies

### DIFF
--- a/isofetcher-browser.js
+++ b/isofetcher-browser.js
@@ -1,0 +1,4 @@
+var fetch = window.fetch;
+var RestUrlify = window.RestUrlify; // this should probably use require() instead
+
+window.IsoFetcher = require('./isofetcher')(fetch, RestUrlify);

--- a/isofetcher-browser.js
+++ b/isofetcher-browser.js
@@ -1,4 +1,4 @@
 var fetch = window.fetch;
-var RestUrlify = window.RestUrlify; // this should probably use require() instead
+var RestUrlify = require('resturlify');
 
-window.IsoFetcher = require('./isofetcher')(fetch, RestUrlify);
+module.exports = require('./isofetcher')(fetch, RestUrlify);

--- a/isofetcher-node.js
+++ b/isofetcher-node.js
@@ -1,0 +1,4 @@
+var fetch = require('node-fetch');
+var RestUrlify = require('resturlify');
+
+module.exports = require('./isofetcher')(fetch, RestUrlify);

--- a/isofetcher.js
+++ b/isofetcher.js
@@ -1,8 +1,7 @@
 'use strict';
 
 module.exports = function (fetch, RestUrlify) {
-
-  var RestResource = function(options) {
+  function RestResource(options) {
     var fqBaseUrl = options.fqBaseUrl || '';
     var resource = options.resource || '';
 
@@ -39,10 +38,10 @@ module.exports = function (fetch, RestUrlify) {
     };
   };
 
-  var IsoFetcher = function(options) {
+  function IsoFetcher(options) {
     var api = {};
     options.resources.forEach( function (resource) {
-      api[resource + ''] = new RestResource( {resource: resource, fqBaseUrl: options.fqBaseUrl} );
+      api[resource] = RestResource( {resource: resource, fqBaseUrl: options.fqBaseUrl} );
     });
     return api;
   };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "isofetcher",
   "version": "0.0.12",
   "description": "Fetch-based REST calls for the browser and Node.js",
-  "main": "isofetcher.js",
+  "main": "isofetcher-node.js",
+  "browser": "isofetcher-browser.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Toybox was pulling in an extra 2.5MB in unused node shims because of the require() lines. Instead of switching the dependencies on an if statement, I inject them from two separate entry point files. package.json specifies which one to use.

This introduces a maybe-breaking change: it *assumes* that the only way this package gets into the browser is via browserify, which seems to be the case for us. A solution that enabled a single file that could be used as-is would likely require using browserify itself to build a distributable file, but we probably don't need to do that.